### PR TITLE
Stricter typing in overloading `Base.length`

### DIFF
--- a/src/multilevel.jl
+++ b/src/multilevel.jl
@@ -60,7 +60,7 @@ Pinv(A) = Pinv{eltype(A)}(A)
 
 (p::Pinv)(x, b) = mul!(x, p.pinvA, b)
 
-Base.length(ml) = length(ml.levels) + 1
+Base.length(ml::MultiLevel) = length(ml.levels) + 1
 
 function Base.show(io::IO, ml::MultiLevel)
     op = operator_complexity(ml)


### PR DESCRIPTION
This overloading of `Base.length(::Any)` causes very confusing error messages when `AlgebraicMultigrid.jl` is loaded. 

(I did not run tests, just editing the file directly on GitHub.)