### PR TITLE
Enable verbose keyword argument

### DIFF
--- a/src/multilevel.jl
+++ b/src/multilevel.jl
@@ -178,6 +178,9 @@ function solve!(x, ml::MultiLevel, b::AbstractArray{T},
             __solve!(x, ml, cycle, b, lvl)
         end
         if calculate_residual
+            if verbose
+                @printf "Norm of residual at iteration %6d is %.4e\n" itr normres
+            end
             mul!(res, A, x)
             reshape(res, size(b)) .= b .- reshape(res, size(b))
             normres = norm(res)


### PR DESCRIPTION
I noticed that the verbose keyword argument didn't do anything, not sure what behavior was intended but here is one possibility.