### PR TITLE
implement W and F cycles and n-dimensional Poisson matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov.io](http://codecov.io/github/JuliaLinearAlgebra/AlgebraicMultigrid.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaLinearAlgebra/AlgebraicMultigrid.jl?branch=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/0wnj4lhk1rvl5pjp?svg=true)](https://ci.appveyor.com/project/ranjanan/algebraicmultigrid-jl)
 
-This package lets you solve sparse linear systems using Algebraic Multigrid (AMG). This works especially well for symmetric positive definite matrices. 
+This package lets you solve sparse linear systems using Algebraic Multigrid (AMG). This works especially well for symmetric positive definite matrices.
 
 ## Usage
 
@@ -40,18 +40,18 @@ You can use AMG as a preconditioner for Krylov methods such as Conjugate Gradien
 ```julia
 import IterativeSolvers: cg
 p = aspreconditioner(ml)
-c = cg(A, A*ones(1000), Pl = p) 
+c = cg(A, A*ones(1000), Pl = p)
 ```
 
 ## Features and Roadmap
 
-This package currently supports: 
+This package currently supports:
 
 AMG Styles:
 * Ruge-Stuben Solver
 * Smoothed Aggregation (SA)
 
-Strength of Connection: 
+Strength of Connection:
 * Classical Strength of Connection
 * Symmetric Strength of Connection
 
@@ -60,12 +60,12 @@ Smoothers:
 * Damped Jacobi
 
 Cycling:
-* V cycle 
+* V, W and F cycles
 
 In the future, this package will support:
 1. Other splitting methods (like CLJP)
 2. SOR smoother
-3. W, F, AMLI cycles
+3. AMLI cycles
 
 #### Acknowledgements
-This package has been heavily inspired by the [`PyAMG`](http://github.com/pyamg/pyamg) project. 
+This package has been heavily inspired by the [`PyAMG`](http://github.com/pyamg/pyamg) project.

--- a/src/gallery.jl
+++ b/src/gallery.jl
@@ -1,3 +1,63 @@
-poisson(T, n) = sparse(Tridiagonal(fill(T(-1), n-1), 
+poisson(T, n) = sparse(Tridiagonal(fill(T(-1), n-1),
                         fill(T(2), n), fill(T(-1), n-1)))
 poisson(n) = poisson(Float64, n)
+
+function stencil_grid(T,stencil,sz)
+    # upper-bound for storage
+    n = prod(sz) * sum(.!iszero,stencil)
+
+    # indices and value of nonzero elements
+    Si = zeros(Int,n)
+    Sj = zeros(Int,n)
+    Ss = zeros(T,n)
+
+    linindices = LinearIndices(sz)
+    nnz = 0
+
+    stencil_sz = size(stencil)
+    offset = CartesianIndex((stencil_sz .+ 1) .÷ 2)
+
+    for i in CartesianIndices(sz)
+        for k in CartesianIndices(stencil_sz)
+            if stencil[k] != 0
+                j = i + k - offset
+                if checkbounds(Bool,linindices,j)
+                    nnz = nnz + 1
+                    Si[nnz] = linindices[i]
+                    Sj[nnz] = linindices[j]
+                    Ss[nnz] = stencil[k]
+                end
+            end
+        end
+    end
+
+    sparse((@view Si[1:nnz]),
+           (@view Sj[1:nnz]),
+           (@view Ss[1:nnz]),
+           prod(sz),prod(sz))
+end
+
+
+
+function poisson(T,sz::NTuple{N,Int}) where N
+    #=
+    In 2D stencil has the value:
+    stencil = [0  -1   0;
+               -1  4  -1;
+               0  -1   0]
+
+    =#
+    stencil = zeros(T,ntuple(i -> 3,Val(N)))
+    for i = 0:N-1
+        Ipre = CartesianIndex(ntuple(l -> 2,i))
+        Ipost = CartesianIndex(ntuple(l -> 2,N-i-1))
+        stencil[Ipre, 1, Ipost] = -1
+        stencil[Ipre, 3, Ipost] = -1
+    end
+    Icenter = CartesianIndex(ntuple(l -> 2,Val(N)))
+    stencil[Icenter] = 2*N
+
+    stencil_grid(T,stencil,sz)
+end
+
+poisson(sz::NTuple{N,Int}) where N = poisson(Float64,sz)

--- a/src/preconditioner.jl
+++ b/src/preconditioner.jl
@@ -1,10 +1,11 @@
-struct Preconditioner{ML<:MultiLevel}
+struct Preconditioner{ML<:MultiLevel,C<:Cycle}
     ml::ML
     init::Symbol
+    cycle::C
 end
-Preconditioner(ml) = Preconditioner(ml, :zero)
+Preconditioner(ml, cycle::Cycle) = Preconditioner(ml, :zero, cycle)
 
-aspreconditioner(ml::MultiLevel) = Preconditioner(ml)
+aspreconditioner(ml::MultiLevel, cycle::Cycle = V()) = Preconditioner(ml,cycle)
 
 import LinearAlgebra: \, *, ldiv!, mul!
 ldiv!(p::Preconditioner, b) = copyto!(b, p \ b)
@@ -14,7 +15,7 @@ function ldiv!(x, p::Preconditioner, b)
     else
         x .= b
     end
-    solve!(x, p.ml, b, maxiter = 1, calculate_residual = false)
+    solve!(x, p.ml, b, p.cycle, maxiter = 1, calculate_residual = false)
 end
 mul!(b, p::Preconditioner, x) = mul!(b, p.ml.levels[1].A, x)
 

--- a/test/cycle_tests.jl
+++ b/test/cycle_tests.jl
@@ -1,0 +1,31 @@
+    import AlgebraicMultigrid: ruge_stuben, smoothed_aggregation,
+    poisson, aspreconditioner
+
+import IterativeSolvers: cg
+
+function test_cycles()
+
+    A = poisson((50,50))
+    b = A * ones(size(A,1))
+
+    reltol = 1e-8
+
+    for method in [ruge_stuben, smoothed_aggregation]
+        ml = method(A)
+
+        for cycle in [AlgebraicMultigrid.V(),AlgebraicMultigrid.W(),AlgebraicMultigrid.F()]
+            x,convhist = solve(ml, b, cycle; reltol = reltol, log = true)
+
+            @debug "number of iterations for $cycle using $method: $(length(convhist))"
+            @test norm(b - A*x) < reltol * norm(b)
+        end
+
+        for cycle in [AlgebraicMultigrid.V(),AlgebraicMultigrid.W(),AlgebraicMultigrid.F()]
+            p = aspreconditioner(ml,cycle)
+
+            x,convhist = cg(A, b, Pl = p; reltol = reltol, log = true)
+            @debug "CG: number of iterations for $cycle using $method: $(convhist.iters)"
+            @test norm(b - A*x) <= reltol * norm(b)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using FileIO
 using Random: seed!
 
 include("sa_tests.jl")
+include("cycle_tests.jl")
 
 @testset "AlgebraicMultigrid Tests" begin
 
@@ -139,6 +140,9 @@ ml = ruge_stuben(A)
 x = solve(ml, A * ones(100))
 @test sum(abs2, x - zeros(100)) < 1e-6
 
+
+
+
 end
 
 @testset "Preconditioning" begin
@@ -237,7 +241,7 @@ for (T,V) in ((Float64, Float64), (Float32,Float32),
         b = V.(b)
         c = cg(a, b, maxiter = 10)
         @test eltype(solve(ml, b)) == eltype(c)
-end    
+end
 
 end
 
@@ -269,6 +273,10 @@ end
 
 @testset "Jacobi Prolongation" begin
     test_jacobi_prolongator()
+end
+
+@testset "Cycles" begin
+    test_cycles()
 end
 
 @testset "Int32 support" begin


### PR DESCRIPTION
This PR implements W and F cycles for the function `solve` using the same approach than [pyamg](https://github.com/pyamg/pyamg/blob/ab2209677c065041e575cbb3ea86ad8cf22af573/pyamg/multilevel.py#L522)
and for the function `aspreconditioner`. To test it on a more realistic configuration I also implemented a multidimensional Poisson function. The number of iterations to reach convergence is the same as `pyamg` for a 1000x1000 Poisson systems (11 for V cycles, and 7 for F and W cycles using `ruge_stuben` and `reltol = 1e-8`) 

Thank you for reviewing this PR.