### PR TITLE
Remove unused dependencies.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AlgebraicMultigrid"
 uuid = "2169fc97-5a83-5252-b627-83903c6c433c"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/Project.toml
+++ b/Project.toml
@@ -4,27 +4,23 @@ version = "0.5.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-CompatHelper = "aa819f21-2bde-4658-8897-bab36330d9b7"
-DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CommonSolve = "0.2"
-CompatHelper = "1.3.0, 2.1, 3"
-IterativeSolvers = "0.9"
 Reexport = "1"
 julia = "1.6"
 
 [extras]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["FileIO", "JLD2", "Random"]
+test = ["DelimitedFiles", "FileIO", "IterativeSolvers", "JLD2", "Random", "Test"]

--- a/src/AlgebraicMultigrid.jl
+++ b/src/AlgebraicMultigrid.jl
@@ -1,7 +1,6 @@
 module AlgebraicMultigrid
 
 using Reexport
-import IterativeSolvers: gauss_seidel!
 using LinearAlgebra
 using SparseArrays, Printf
 using Base.Threads


### PR DESCRIPTION
This drops the following from direct and indirect dependencies:
```
 - Compat v3.41.0
 - CompatHelper v3.1.0
 - ExprTools v0.1.8
 - GitForge v0.2.8
 - HTTP v0.9.17
 - IniFile v0.5.0
 - InlineStrings v1.1.2
 - IterativeSolvers v0.9.2
 - JSON2 v0.3.4
 - MbedTLS v1.0.3
 - Mocking v0.7.3
 - MultilineStrings v0.1.1
 - Parsers v2.2.1
 - RecipesBase v1.2.1
 - TimeZones v1.7.1
 - URIs v1.3.0
 - ArgTools
 - Base64
 - Dates
 - DelimitedFiles
 - Distributed
 - Downloads
 - InteractiveUtils
 - LazyArtifacts
 - LibCURL
 - LibGit2
 - Logging
 - Markdown
 - Mmap
 - NetworkOptions
 - Pkg
 - REPL
 - SharedArrays
 - Sockets
 - Statistics
 - TOML
 - Tar
 - Test
 - UUIDs
 - LibCURL_jll
 - LibSSH2_jll
 - MbedTLS_jll
 - MozillaCACerts_jll
 - Zlib_jll
 - nghttp2_jll
 - p7zip_jll
```