### PR TITLE
Extend Ruge-Stuben solver to complex type

### DIFF
--- a/src/classical.jl
+++ b/src/classical.jl
@@ -45,6 +45,7 @@ function extend_heirarchy!(levels, strength, CF, A::SparseMatrixCSC{Ti,Tv}, symm
 end
 
 function direct_interpolation(At, T, splitting)
+    T = typeof(At)(T)
     fill!(T.nzval, eltype(At)(1))
     T .= At .* T
     
@@ -99,7 +100,7 @@ function rs_direct_interpolation_pass2(At::SparseMatrixCSC{Tv,Ti},
                 row = T.rowval[j]
                 sval = T.nzval[j]
                 if splitting[row] == C_NODE
-                    if sval < 0
+                    if real(sval) < 0
                         sum_strong_neg += sval
                     else
                         sum_strong_pos += sval
@@ -115,7 +116,7 @@ function rs_direct_interpolation_pass2(At::SparseMatrixCSC{Tv,Ti},
                 if row == i
                     diag += aval
                 else
-                    if aval < 0
+                    if real(aval) < 0
                         sum_all_neg += aval
                     else
                         sum_all_pos += aval
@@ -125,7 +126,7 @@ function rs_direct_interpolation_pass2(At::SparseMatrixCSC{Tv,Ti},
 
             if sum_strong_pos == 0
                 beta = zero(diag)
-                if diag >= 0
+                if real(diag) >= 0
                     diag += sum_all_pos
                 end
             else
@@ -134,14 +135,14 @@ function rs_direct_interpolation_pass2(At::SparseMatrixCSC{Tv,Ti},
 
             if sum_strong_neg == 0
                 alpha = zero(diag)
-                if diag < 0
+                if real(diag) < 0
                     diag += sum_all_neg
                 end
             else
                 alpha = sum_all_neg / sum_strong_neg
             end
 
-            if isapprox(diag, 0, atol=eps(Tv))
+            if isapprox(real(diag), 0, atol=eps(real(Tv)))
                 neg_coeff = Tv(0)
                 pos_coeff = Tv(0)
             else
@@ -155,7 +156,7 @@ function rs_direct_interpolation_pass2(At::SparseMatrixCSC{Tv,Ti},
                 sval = T.nzval[j]
                 if splitting[row] == C_NODE
                     Bj[nnz] = row
-                    if sval < 0
+                    if real(sval) < 0
                         Bx[nnz] = abs(neg_coeff * sval)
                     else
                         Bx[nnz] = abs(pos_coeff * sval)

--- a/src/strength.jl
+++ b/src/strength.jl
@@ -9,7 +9,7 @@ function (c::Classical)(At::SparseMatrixCSC{Tv,Ti}) where {Ti,Tv}
     θ = c.θ
 
     m, n = size(At)
-    T = copy(At)
+    T = real(copy(At))
 
     for i = 1:n
         _m = find_max_off_diag(T, i)
@@ -37,7 +37,7 @@ function (c::Classical)(At::SparseMatrixCSC{Tv,Ti}) where {Ti,Tv}
 end
 
 function find_max_off_diag(A, i)
-    m = zero(eltype(A))
+    m = real(zero(eltype(A)))
     for j in nzrange(A, i)
         row = A.rowval[j]
         val = A.nzval[j]


### PR DESCRIPTION
This PR shows minimum changes to allow `ruge_stuben` to take complex-valued matrix. 

It seems to converge well for simple problems:

```julia
using LinearAlgebra
using AlgebraicMultigrid
A = poisson((32, 32, 32)) + 1.0im * I
ml = ruge_stuben(A)

n = size(A)[1]
b = ones(n) * (1.0 + 1.0im)
x = AlgebraicMultigrid._solve(ml, b; verbose=true, maxiter=10)
@assert norm(b - A*x) < 1e-6
```

```
Norm of residual at iteration      1 is 2.5600e+02
Norm of residual at iteration      2 is 4.5756e+00
Norm of residual at iteration      3 is 5.9946e-02
Norm of residual at iteration      4 is 9.5474e-04
Norm of residual at iteration      5 is 1.7687e-05
```

From literature on complex-valued AMG ([Algebraic Multigrid Solvers for Complex-Valued Matrices](https://epubs.siam.org/doi/abs/10.1137/070687232) and [A multigrid-based shifted Laplacian preconditioner for a fourth-order Helmholtz discretization](https://onlinelibrary.wiley.com/doi/abs/10.1002/nla.634); see also pyamg/pyamg#327), the AMG interpolation formula carries straightly from real to complex cases. So this PR just tweaks `max()`, `>` operators to support complex numbers.